### PR TITLE
Add a link to the foundation budget

### DIFF
--- a/doc/finance.md
+++ b/doc/finance.md
@@ -2,6 +2,11 @@
 
 ## Where can I find the budget?
 
-See [this Google Drive folder for our budget information](https://drive.google.com/drive/folders/1a6E7PGOe6MlTsiVQBo4-ZyooDuAltuaY?usp=drive_link).
+See [the Board Google Drive](#google-drive) for our budget information.
+It is in the {kbd}`Governing Board` -> {kbd}`Budget` folder.
 
-In addition, the [Monthly Summaries folder](https://drive.google.com/drive/folders/1oR_N5ofVfPlWus0BHV4KtTWj4JeEiONn?usp=drive_link) contains an updated budget with the latest information about expenses.
+## Where can I find monthly summaries of the budget?
+
+The **Monthly Summaries folder** contains an updated budget with the latest information about expenses.
+It is in [the Board Google Drive](#google-drive).
+Find the {kbd}`Governing Board` -> {kbd}`Budget` -> {kbd}`Monthly summaries` folder.

--- a/doc/finance.md
+++ b/doc/finance.md
@@ -1,0 +1,7 @@
+# Accounting and finances
+
+## Where can I find the budget?
+
+See [this Google Drive folder for our budget information](https://drive.google.com/drive/folders/1a6E7PGOe6MlTsiVQBo4-ZyooDuAltuaY?usp=drive_link).
+
+In addition, the [Monthly Summaries folder](https://drive.google.com/drive/folders/1oR_N5ofVfPlWus0BHV4KtTWj4JeEiONn?usp=drive_link) contains an updated budget with the latest information about expenses.

--- a/doc/index.md
+++ b/doc/index.md
@@ -8,5 +8,20 @@ This Team Compass is very young and still a work in progress. It is likely missi
 
 ## Where information is located
 
-- [Our GitHub repository](https://github.com/jupyter-governance/jupyter-foundation-governing-board) has all the source files for this team compass.
-- [The Governing Board Google Drive folder](https://drive.google.com/drive/folders/1RIBUYQk8xN1-vHs4bqLM8Chj8tWOfM90?usp=drive_link) has most of our working documents.
+### Our GitHub repository
+
+[Our GitHub repository](https://github.com/jupyter-governance/jupyter-foundation-governing-board) has all the source files for this team compass.
+
+(google-drive)=
+
+### Board Google Drive Folder
+
+**The Governing Board Google Drive folder** has most of our working documents. We don't share this link publicly since it has sensitive information. For access, please message one of the board members.
+
+## Guidelines for sensitive information
+
+This is a public website, so only provide information and links that are reasonable to be shared publicly.
+_Avoid sharing links to sensitive information, even if it is behind an authentication wall_.
+For now we wish to be biased on the conservative side and reduce the risk of unwanted access.
+
+If you'd like to share sensitive information, document its existence here, and provide general directions for how to find it in [the Board's Google Drive](#google-drive).

--- a/doc/myst.yml
+++ b/doc/myst.yml
@@ -13,6 +13,7 @@ project:
   toc:
     - file: index.md
     - file: admin.md
+    - file: finance.md
     - title: Meeting Notes
       children:
       - file: meetings/2025.md


### PR DESCRIPTION
This adds documentation to link to our budget folders.

**This does not make the budget accessible to anyone outside of the board members.** It is only the _link_ to the budget, and the link is behind a login wall. This would be similar to linking to a page in the LFX system that required you to sign in first before you could access it.

Here's what will happen if you click that link:

- If you are not signed in with Google, it will require you to sign in.
- If you sign in but don't have permissions to access that folder, you will hit the "request access" form page.