### PR TITLE
Document the domain and support e-mails

### DIFF
--- a/doc/admin.md
+++ b/doc/admin.md
@@ -16,3 +16,15 @@ The Program Manager is our primary point-of-contact with the Linux Foundation, a
 The best way to send messages is via e-mail, please ask another Foundation member if you need it.
 
 Our Program Manager is [Naomi Washington](https://www.linkedin.com/in/naomiwashington/).
+
+(support)=
+## How to get support from the Linux Foundation
+
+We have a few different avenues for support from the Linux Foundation.
+The easiest route is to e-mail `support@jupyterfoundation.org` with your question, and they'll get back to you.
+You can also reach out to [our Program Manager](#program-manager).
+
+## How to control the jupyterfoundation.org domain
+
+While most subdomains are controlled by [Jupyter's Cloudflare](xref:jec#cloudflare), the domain `jupyterfoundation.org` is controlled by the Linux Foundation.
+If you wish to make modifications to this domain, reach out to [the LF support e-mail](#support).

--- a/doc/myst.yml
+++ b/doc/myst.yml
@@ -9,6 +9,10 @@ project:
   github: https://github.com/jupyter-governance/jupyter-foundation-governing-board
   abbreviations:
     LF: The Linux Foundation
+    JEC: Jupyter Executive Council
+  project:
+    references:
+      jec: https://executive-council-team-compass.readthedocs.io/en/latest/
   toc:
     - file: index.md
     - file: admin.md


### PR DESCRIPTION
This documents three things:

- The support contact for LF
- The ownership of the jupyterfoundation.org domain
- Adds the JEC team compass for cross-ref labels so we can link between the two