### PR TITLE
Add initial goals, strategy, and structural documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # The Jupyter Foundation Board Team Compass
 
-This is the Team Compass for the Jupyter Foundation Board, for more information on what that means, see [the contributing guidelines](doc/contribute.md) for more information.
+This is the Team Compass for the Jupyter Foundation Board. It is the source of truth for this team.
+
+## Where to find the team compass
+
+The Team Compass is hosted via GitHub Pages at the following URL:
+
+https://jupyter.org/governance/people.html#jupyter-foundation-governing-board
+
+## How to contribute to the team compass
+
+See [the contributing guidelines](doc/contribute.md) for more information.

--- a/doc/about.md
+++ b/doc/about.md
@@ -2,7 +2,7 @@
 
 ## Our Mission
 
-The Jupyter Foundation exists to ensure that Jupyter’s community has the resources it needs to build sustainable, reliable, and impactful technology.
+The Jupyter Foundation exists to ensure that Project Jupyter has the resources it needs to build sustainable, reliable, and impactful technology.
 
 ## What is the Foundation’s problem to solve?
 

--- a/doc/about.md
+++ b/doc/about.md
@@ -65,6 +65,6 @@ If a subcommittee has members that are not also on the Board, then any decisions
 
 This is still a work in progress. The Board has initially defined the following subcommittees:
 
-- **Technical Support Committee** - dedicated to improving the quality, reliability, and safety of Jupyter's technical infrastructure.
+- **Technical Support Committee** - dedicated to improving the quality, reliability, and safety of Project Jupyter's software.
 - **Community Support Committee** - dedicated to improving the health of Project Jupyter's contributor community.
 - **Foundation Membership Development Committee** - dedicated to ensuring that the Jupyter Foundation membership grows and benefits from the Foundation.

--- a/doc/about.md
+++ b/doc/about.md
@@ -1,0 +1,69 @@
+# About the Jupyter Foundation
+
+## Our Mission
+
+The Jupyter Foundation exists to ensure that Jupyter’s community has the resources it needs to build sustainable, reliable, and impactful technology.
+
+## What is the Foundation’s problem to solve?
+
+As Jupyter has grown its impact, it has had an increasing lack of resources needed to drive the project forward. This creates risk for both the Jupyter maintainers (who feel an increasing burden to deliver impactful software to a growing user base) as well as for the members of the Jupyter Foundation (who depend on Jupyter being a reliable and innovating technology organization).
+
+A major source of stress is the *lack of financial resources* needed to ensure Jupyter can sustainably meet its own goals, and the goals of the Foundation’s member organizations. Many companies have financial resources and a desire to support Jupyter, staff that are interested in contributing, and unique perspectives that can help Jupyter build tools that are more impactful. 
+
+However, Jupyter’s community is often opaque and has many different stakeholders and needs. Its community is often skeptical of “top-down” signals or requests. **The Foundation is an opportunity to provide financial and strategic resources that help Project Jupyter be more reliable and effective for all of its stakeholders. To do so effectively, it must deliver clear value to both the Jupyter community and to the Foundation member communities.**
+
+## Who we are
+
+[Membership of the Jupyter Foundation governing board](https://jupyter.org/governance/people.html#jupyter-foundation-governing-board).
+
+## How we are structured
+
+The Jupyter Foundation Board membership structure is defined [here in the Jupyter governance documentation](https://jupyter.org/governance/jupyter_foundation.html#membership).
+
+In addition there are a few specific roles and groups defined within the board, described below.f
+
+(board-chair)=
+### Board Chair
+
+The Board Chair leads the board in conducting discussion and decisions that accomplish the Board's goals. The board is intentionally keeping this role scoped tightly, to recognize that we are bootstrapping the role, and to recognize that detailed responsibilities will be *defined* by the board chair in partnership with the board. Below are the responsibilities for this role:
+
+- Plan and lead board meetings  
+- Set the agenda   
+  - Define objectives - make sure the agenda matches the objectives.  
+- Coordinate with the [Linux Foundation PM](#program-manager) to assist the board  
+  - Review meeting agendas, budget, minutes, etc.  
+- Facilitate the creation and delegation of authority / responsibility to subcommittees
+
+#### Who is the current board chair?
+
+[Rus Pandey](https://www.linkedin.com/in/rusp/) is the Foundation Board's current board chair.
+
+#### How is the board chair elected?
+
+The Board elects a chair with a majority vote of its members.
+
+(subcommittees)=
+### Subcommittees
+
+A subcommittee is an ongoing working group of board members that focuses on a thematic area over time. They were initially formed around [the Foundation's goals and strategy](./strategy.md).
+
+#### What is the purpose of subcommittees?
+
+The primary goals of subcommittees are to:
+
+- Make proposals to the Foundation Board that accomplish the goals in their thematic area.
+- Oversee the implementation of funds according to proposals that have been accepted, where applicable.
+
+#### How do we determine membership of subcommittees?
+
+By default, subcommittees are only open to Foundation board members. However, subcommittees may elect to open their membership to non-board Foundation members.
+
+If a subcommittee has members that are not also on the board, then any decisions around funding must be made with a majority vote of the board members.
+
+#### List of subcommittees
+
+This is still a work in progress. The Board has initially defined the following committees:
+
+- **Technical Support Committee** - dedicated to improving the quality, reliability, and safety of Jupyter's technical infrastructure.
+- **Community Support Committee** - dedicated to improving the health of Jupyter's contributor community.
+- **Foundation Membership Development Committee** - dedicated to ensuring that the Jupyter Foundation membership grows and benefits from the Foundation.

--- a/doc/about.md
+++ b/doc/about.md
@@ -8,35 +8,36 @@ The Jupyter Foundation exists to ensure that Project Jupyter has the resources i
 
 As Jupyter has grown its impact, it has had an increasing lack of resources needed to drive the project forward. This creates risk for both the Jupyter maintainers (who feel an increasing burden to deliver impactful software to a growing user base) as well as for the members of the Jupyter Foundation (who depend on Jupyter being a reliable and innovating technology organization).
 
-A major source of stress is the *lack of financial resources* needed to ensure Jupyter can sustainably meet its own goals, and the goals of the Foundation’s member organizations. Many companies have financial resources and a desire to support Jupyter, staff that are interested in contributing, and unique perspectives that can help Jupyter build tools that are more impactful. 
+A major source of stress is the *lack of financial resources* needed to ensure Jupyter can sustainably meet its own goals and the goals of the Foundation’s member organizations. Many companies desire to support Jupyter with financial resources, staff that are interested in contributing, and unique perspectives that can help Jupyter build tools that are more impactful. 
 
-However, Jupyter’s community is often opaque and has many different stakeholders and needs. Its community is often skeptical of “top-down” signals or requests. **The Foundation is an opportunity to provide financial and strategic resources that help Project Jupyter be more reliable and effective for all of its stakeholders. To do so effectively, it must deliver clear value to both the Jupyter community and to the Foundation member communities.**
+However, Jupyter’s community is often opaque and has many different stakeholders and needs. Its community is often skeptical of “top-down” signals or requests. **The Foundation is an opportunity to provide financial and strategic resources that help Project Jupyter be more reliable and effective for all of its stakeholders. To do so effectively, the Foundation must deliver clear value to both the Jupyter community and to the Foundation member communities.**
 
 ## Who we are
 
-[Membership of the Jupyter Foundation governing board](https://jupyter.org/governance/people.html#jupyter-foundation-governing-board).
+* [Jupyter Foundation Governing Board](https://jupyter.org/governance/people.html#jupyter-foundation-governing-board)
+* [Jupyter Foundation Members](https://jupyterfoundation.org/members/)
 
 ## How we are structured
 
-The Jupyter Foundation Board membership structure is defined [here in the Jupyter governance documentation](https://jupyter.org/governance/jupyter_foundation.html#membership).
+The Jupyter Foundation structure is defined [here in the Jupyter governance documentation](https://jupyter.org/governance/jupyter_foundation.html#membership).
 
-In addition there are a few specific roles and groups defined within the board, described below.f
+In addition, there are a few specific roles and groups defined within the Jupyter Foundation and its Governing Board, described below.
 
 (board-chair)=
 ### Board Chair
 
-The Board Chair leads the board in conducting discussion and decisions that accomplish the Board's goals. The board is intentionally keeping this role scoped tightly, to recognize that we are bootstrapping the role, and to recognize that detailed responsibilities will be *defined* by the board chair in partnership with the board. Below are the responsibilities for this role:
+The Board Chair leads the Jupyter Foundation Governing Board ("Board") in conducting discussion and decisions that accomplish the Board's goals. The Board is intentionally keeping this role scoped tightly, to recognize that we are bootstrapping the role and to recognize that detailed responsibilities will be *defined* by the Board Chair in partnership with the Board. Below are the responsibilities for this role:
 
-- Plan and lead board meetings  
+- Plan and lead Board meetings  
 - Set the agenda   
   - Define objectives - make sure the agenda matches the objectives.  
-- Coordinate with the [Linux Foundation PM](#program-manager) to assist the board  
+- Coordinate with the [Linux Foundation Program Manager](#program-manager) to assist the board  
   - Review meeting agendas, budget, minutes, etc.  
-- Facilitate the creation and delegation of authority / responsibility to subcommittees
+- Facilitate the creation and delegation of authority / responsibility to Jupyter Foundation subcommittees
 
-#### Who is the current board chair?
+#### Who is the current Board Chair?
 
-[Rus Pandey](https://www.linkedin.com/in/rusp/) is the Foundation Board's current board chair.
+[Rus Pandey](https://www.linkedin.com/in/rusp/) is the Foundation Board's current Board Chair.
 
 #### How is the board chair elected?
 
@@ -45,7 +46,7 @@ The Board elects a chair with a majority vote of its members.
 (subcommittees)=
 ### Subcommittees
 
-A subcommittee is an ongoing working group of board members that focuses on a thematic area over time. They were initially formed around [the Foundation's goals and strategy](./strategy.md).
+A subcommittee is an ongoing working group of Board members that focuses on a thematic area over time. They were initially formed around [the Foundation's goals and strategy](./strategy.md).
 
 #### What is the purpose of subcommittees?
 
@@ -56,14 +57,14 @@ The primary goals of subcommittees are to:
 
 #### How do we determine membership of subcommittees?
 
-By default, subcommittees are only open to Foundation board members. However, subcommittees may elect to open their membership to non-board Foundation members.
+By default, subcommittees are only open to Foundation Board members. However, subcommittees may elect to open their membership to all Foundation members.
 
-If a subcommittee has members that are not also on the board, then any decisions around funding must be made with a majority vote of the board members.
+If a subcommittee has members that are not also on the Board, then any decisions around funding must be made with a majority vote of the Board members on the subcommittee.
 
 #### List of subcommittees
 
-This is still a work in progress. The Board has initially defined the following committees:
+This is still a work in progress. The Board has initially defined the following subcommittees:
 
 - **Technical Support Committee** - dedicated to improving the quality, reliability, and safety of Jupyter's technical infrastructure.
-- **Community Support Committee** - dedicated to improving the health of Jupyter's contributor community.
+- **Community Support Committee** - dedicated to improving the health of Project Jupyter's contributor community.
 - **Foundation Membership Development Committee** - dedicated to ensuring that the Jupyter Foundation membership grows and benefits from the Foundation.

--- a/doc/communication.md
+++ b/doc/communication.md
@@ -1,0 +1,8 @@
+# Communications
+
+## Internal communication
+
+We have a private Zulip channel in [the Jupyter Zulip](https://jupyter.zulipchat.com/).
+All board members should be added to this channel.
+If you are not, ask a member of the Jupyter Executive Council to add you.
+

--- a/doc/funding/priorities.md
+++ b/doc/funding/priorities.md
@@ -1,0 +1,68 @@
+
+# Funding priorities
+
+_We agreed upon the following areas to prioritize for funding. These were identified as critical shared needs by both the Jupyter Community as well as the Member organizations._
+
+## Grow the contributor capacity of Jupyter
+
+A consistent challenge within Jupyter’s community is the lack of resources and time to maintain and develop its technology and community. At the same time, Foundation Member organizations have many people who are interested in contributing, but face barriers to doing so.
+
+By using Foundation funding to **grow the contributor capacity in the Jupyter ecosystem**, we can alleviate a key burden on Jupyter’s pre-existing maintainers, and provide an easier way for Member organizations to participate and contribute. 
+
+### Key outcomes
+
+1. **Grow the number of contributors.** It is easier for any contributor, regardless of their organizational affiliation, to contribute to Jupyter and sustain their participation. We’ll measure success by recording the contributions (PRs, issue participation, etc) that come from non-maintainers, as well as the growth in self-identified contributors over time.  
+2. **Improve the efficiency of our contributors.** It takes less effort to maintain and develop technology in the Jupyter ecosystem. This includes reducing toil, automating common actions, defining processes and responsibility that helps us execute more reliably and effectively, etc.  
+3. **Facilitate learning across the Jupyter subprojects.** Currently many subprojects act as independent and self-contained teams. They do not have a reliable way for learning from others in the Jupyter ecosystem, sharing resources, and sharing skills. Creating mechanisms for connecting these separate parts of the Jupyter ecosystem will result in more coherent and efficient actions across its community.
+
+### Examples of how to grow contributor capacity
+
+- Hold events that grow Jupyter’s visibility and presence.  
+- Hold events that give newcomers an opportunity to collaborate with maintainers in real-time to gain comfort with participating in the project.  
+- Improve the documentation for navigating the Jupyter project as a whole (e.g., helping newcomers understand the project’s subprojects, skills needed to contribute to each, etc)  
+- Improve the documentation across each of Jupyter’s subprojects, with an emphasis on contributing documentation.  
+- Fund maintainer time to organize community meetings and coordinate their efforts, with an emphasis on making them accessible and useful to non-maintainers. (for example, a “Developer Experience” or “Community Manager” role)  
+- Fund regular, low-effort events that give others an opportunity to pair with maintainers in common maintainer actions like PR review, issue triage, etc.  
+- Fund maintainer time to steward contributions from external contributors and provide them feedback with the goal of increasing their comfort with contributing.  
+- Fund development work on maintainer infrastructure that reduces toil and grows efficiency (e.g., improving the Jupyter Releaser technology and documentation)
+
+## Improve the reliability, security, and consistency of Jupyter’s software
+
+Many of Jupyter’s repositories lack the capacity needed to be considered reliable, safe, and consistent. This is due to a combination of bandwidth constraints, tooling, training, and coordination. As a result, Jupyter’s subprojects often accrue technical debt that burns out their maintainers, and that increases the variability of their outputs. Member organizations have a desire for Jupyter’s technology to be *reliable, safe, and consistent*. This allows them to confidently build their own technical dependencies on Jupyter technology and use them in production contexts.
+
+By using Foundation funding to **improve the reliability, security, and consistency of Jupyter’s software and team practices**, we can help Jupyter community members more sustainably manage their technical and team debt, release more reliable software, and reduce the burden on user organizations that deploy this software internally.
+
+### Key outcomes
+
+1. **Increase contributor perception of the software quality.** Jupyter's community members are valid assessors of Jupyter’s software quality, since many are professional software engineers and because their perception influences their engagement with Jupyter. We will measure their perception of Jupyter’s software quality through community outreach efforts, such as a semi-annual survey.
+2. **Increase testing code coverage.** Software testing is a fundamental aspect of ensuring a base level of software quality. We will identify a set of key repositories based on usage and dependencies and track the amount of source code covered by tests at all levels.  
+3. **Increase the frequency and transparency of minor releases.** “Release early, release often”, with an emphasis on minor releases providing bug fixes, security patches, non-disruptive performance improvements, and similarly non-disruptive new features. Ensure that releases always make it clear what has changed and what it means for a user. Minor releases with these characteristics are easier for Jupyter users and operators to deploy. This pattern also keeps the contributors familiar with the release process.  
+4. **Increase the speed of security fixes.** Security vulnerabilities are a strong concern for organizations that deploy Jupyter technology as part of shared services. Improvements to Jupyter’s overall software quality should result in faster, more efficient processes for identifying, resolving, and releasing security errors.
+
+### Examples of how to grow software quality
+
+- Hold events that allow subprojects to meet and co-work to solve their most pressing problems.  
+- Fund contributor time to focus on security, testing coverage, etc.  
+- Fund contributor time to create more consistent releases with higher-quality release notes across the project.  
+- Fund development efforts to build common infrastructure for releases, documentation, and testing across the Jupyter ecosystem.  
+- Fund contributor time to focus on stewarding pull-requests, with a focus on maintenance and bug fixes.  
+- Fund contributor time for stewarding JEPs and encouraging productive and efficient cross-community conversation.
+
+## Ensure that Jupyter has a reliable source of funding by developing the Jupyter Foundation 
+
+The funding mechanisms we define will only be effective if we can reliably engage and grow the members of the Jupyter Foundation. Doing so will require dedicated capacity to ensure that the Foundation is delivering value to its members, and to engage *prospective* members to grow the foundation.
+
+By using Foundation funding to **develop the Foundation membership and ensure it delivers value to them**, we will increase the likelihood that our foundation’s members are engaged and satisfied with their participation. This will reduce churn and increase our chances of increasing financial resources for the project.
+
+### Key outcomes
+
+- **Jupyter Foundation members find value in their membership**. The primary goal of this group is to ensure that the members of the Jupyter Foundation are engaged, see their interests represented, and generally see value in their membership with the Jupyter Foundation.
+- **The Jupyter Foundation has the resources it needs to accomplish its goals**. In order to ensure that the Foundation can meet its goals, the Foundation needs financial resources from its paying members. This committee also aims to grow the Foundation to a level that allows it to accomplish its goals.
+
+### Examples of how to develop the Foundation
+
+- Identify the necessary roles on the Board and to sustain its operations (e.g., Treasurer, Executive Director)  
+- Create feedback loops between the Jupyter community, the Jupyter Executive Council, Member Organizations, and the Foundation (both synchronous and asynchronous)  
+- Develop mechanisms for reporting progress and outcomes to Members to sustain/grow funding commitments  
+- Develop mechanisms to enable Member Organizations to shape funding priorities and balance this input with the needs of the Jupyter community  
+- Give Jupyter subprojects visibility into the Foundation’s activities and opportunities for input

--- a/doc/funding/priorities.md
+++ b/doc/funding/priorities.md
@@ -7,11 +7,11 @@ _We agreed upon the following areas to prioritize for funding. These were identi
 
 A consistent challenge within Jupyter’s community is the lack of resources and time to maintain and develop its technology and community. At the same time, Foundation Member organizations have many people who are interested in contributing, but face barriers to doing so.
 
-By using Foundation funding to **grow the contributor capacity in the Jupyter ecosystem**, we can alleviate a key burden on Jupyter’s pre-existing maintainers, and provide an easier way for Member organizations to participate and contribute. 
+By using Foundation funding to **grow the contributor capacity in the Jupyter ecosystem**, we can alleviate a key burden on Jupyter’s existing maintainers and provide an easier way for Member organizations to participate and contribute. 
 
 ### Key outcomes
 
-1. **Grow the number of contributors.** It is easier for any contributor, regardless of their organizational affiliation, to contribute to Jupyter and sustain their participation. We’ll measure success by recording the contributions (PRs, issue participation, etc) that come from non-maintainers, as well as the growth in self-identified contributors over time.  
+1. **Grow the number of contributors.** It is easier for any contributor, regardless of their organizational affiliation, to contribute to Jupyter and sustain their participation. We’ll measure success by recording the contributions (PRs, issue participation, etc.) that come from non-maintainers, as well as the growth in self-identified contributors over time.  
 2. **Improve the efficiency of our contributors.** It takes less effort to maintain and develop technology in the Jupyter ecosystem. This includes reducing toil, automating common actions, defining processes and responsibility that helps us execute more reliably and effectively, etc.  
 3. **Facilitate learning across the Jupyter subprojects.** Currently many subprojects act as independent and self-contained teams. They do not have a reliable way for learning from others in the Jupyter ecosystem, sharing resources, and sharing skills. Creating mechanisms for connecting these separate parts of the Jupyter ecosystem will result in more coherent and efficient actions across its community.
 
@@ -20,7 +20,7 @@ By using Foundation funding to **grow the contributor capacity in the Jupyter ec
 - Hold events that grow Jupyter’s visibility and presence.  
 - Hold events that give newcomers an opportunity to collaborate with maintainers in real-time to gain comfort with participating in the project.  
 - Improve the documentation for navigating the Jupyter project as a whole (e.g., helping newcomers understand the project’s subprojects, skills needed to contribute to each, etc)  
-- Improve the documentation across each of Jupyter’s subprojects, with an emphasis on contributing documentation.  
+- Improve the documentation across each of Jupyter’s subprojects, with an emphasis on documentation for contributors.
 - Fund maintainer time to organize community meetings and coordinate their efforts, with an emphasis on making them accessible and useful to non-maintainers. (for example, a “Developer Experience” or “Community Manager” role)  
 - Fund regular, low-effort events that give others an opportunity to pair with maintainers in common maintainer actions like PR review, issue triage, etc.  
 - Fund maintainer time to steward contributions from external contributors and provide them feedback with the goal of increasing their comfort with contributing.  
@@ -50,9 +50,9 @@ By using Foundation funding to **improve the reliability, security, and consiste
 
 ## Ensure that Jupyter has a reliable source of funding by developing the Jupyter Foundation 
 
-The funding mechanisms we define will only be effective if we can reliably engage and grow the members of the Jupyter Foundation. Doing so will require dedicated capacity to ensure that the Foundation is delivering value to its members, and to engage *prospective* members to grow the foundation.
+The funding mechanisms we define will only be effective if we can reliably engage and grow the members of the Jupyter Foundation. Doing so will require dedicated capacity to ensure that the Foundation is delivering value to its members and to engage *prospective* members to grow the foundation.
 
-By using Foundation funding to **develop the Foundation membership and ensure it delivers value to them**, we will increase the likelihood that our foundation’s members are engaged and satisfied with their participation. This will reduce churn and increase our chances of increasing financial resources for the project.
+By using Foundation funding to **develop the Foundation membership and ensure it delivers value to them**, we will increase the likelihood that the Foundation’s members are engaged and satisfied with their participation. This will reduce churn and increase our chances of increasing financial resources for the project.
 
 ### Key outcomes
 
@@ -61,7 +61,7 @@ By using Foundation funding to **develop the Foundation membership and ensure it
 
 ### Examples of how to develop the Foundation
 
-- Identify the necessary roles on the Board and to sustain its operations (e.g., Treasurer, Executive Director)  
+- Identify the necessary roles to sustain the Foundation operations (e.g., Treasurer, Executive Director)
 - Create feedback loops between the Jupyter community, the Jupyter Executive Council, Member Organizations, and the Foundation (both synchronous and asynchronous)  
 - Develop mechanisms for reporting progress and outcomes to Members to sustain/grow funding commitments  
 - Develop mechanisms to enable Member Organizations to shape funding priorities and balance this input with the needs of the Jupyter community  

--- a/doc/funding/priorities.md
+++ b/doc/funding/priorities.md
@@ -11,6 +11,8 @@ By using Foundation funding to **grow the contributor capacity in the Jupyter ec
 
 ### Key outcomes
 
+_These are likely not exhaustive, but are included to help us understand the kind of impact each goal should have._
+
 1. **Grow the number of contributors.** It is easier for any contributor, regardless of their organizational affiliation, to contribute to Jupyter and sustain their participation. We’ll measure success by recording the contributions (PRs, issue participation, etc.) that come from non-maintainers, as well as the growth in self-identified contributors over time.  
 2. **Improve the efficiency of our contributors.** It takes less effort to maintain and develop technology in the Jupyter ecosystem. This includes reducing toil, automating common actions, defining processes and responsibility that helps us execute more reliably and effectively, etc.  
 3. **Facilitate learning across the Jupyter subprojects.** Currently many subprojects act as independent and self-contained teams. They do not have a reliable way for learning from others in the Jupyter ecosystem, sharing resources, and sharing skills. Creating mechanisms for connecting these separate parts of the Jupyter ecosystem will result in more coherent and efficient actions across its community.
@@ -34,6 +36,8 @@ By using Foundation funding to **improve the reliability, security, and consiste
 
 ### Key outcomes
 
+_These are likely not exhaustive, but are included to help us understand the kind of impact each goal should have._
+
 1. **Increase contributor perception of the software quality.** Jupyter's community members are valid assessors of Jupyter’s software quality, since many are professional software engineers and because their perception influences their engagement with Jupyter. We will measure their perception of Jupyter’s software quality through community outreach efforts, such as a semi-annual survey.
 2. **Increase testing code coverage.** Software testing is a fundamental aspect of ensuring a base level of software quality. We will identify a set of key repositories based on usage and dependencies and track the amount of source code covered by tests at all levels.  
 3. **Increase the frequency and transparency of minor releases.** “Release early, release often”, with an emphasis on minor releases providing bug fixes, security patches, non-disruptive performance improvements, and similarly non-disruptive new features. Ensure that releases always make it clear what has changed and what it means for a user. Minor releases with these characteristics are easier for Jupyter users and operators to deploy. This pattern also keeps the contributors familiar with the release process.  
@@ -55,6 +59,8 @@ The funding mechanisms we define will only be effective if we can reliably engag
 By using Foundation funding to **develop the Foundation membership and ensure it delivers value to them**, we will increase the likelihood that the Foundation’s members are engaged and satisfied with their participation. This will reduce churn and increase our chances of increasing financial resources for the project.
 
 ### Key outcomes
+
+_These are likely not exhaustive, but are included to help us understand the kind of impact each goal should have._
 
 - **Jupyter Foundation members find value in their membership**. The primary goal of this group is to ensure that the members of the Jupyter Foundation are engaged, see their interests represented, and generally see value in their membership with the Jupyter Foundation.
 - **The Jupyter Foundation has the resources it needs to accomplish its goals**. In order to ensure that the Foundation can meet its goals, the Foundation needs financial resources from its paying members. This committee also aims to grow the Foundation to a level that allows it to accomplish its goals.

--- a/doc/funding/process.md
+++ b/doc/funding/process.md
@@ -1,0 +1,10 @@
+# Process for funding
+
+Our process for funding is still a working draft.
+This is the process the board currently follows, and it will improve the details of this process as we begin taking our first steps.
+
+- The [Board Chair](#board-chair) is accountable for ensuring the Board understands its budget.
+- [Subcommittees](#subcommittees) (or individual board members) make proposals for funding to the Board.
+- The Board takes a vote on whether to fund each proposal.
+- If proposals are accepted, the board will delegate the implementation of the proposal to a subcommittee or individual on the board.
+- If subcommittees are responsible for implementing a proposal, then a **majority vote of the Governing Board members on the subcommittee** makes decision about how to spend the funds, as long as it is under the total amount in the proposal.   

--- a/doc/funding/process.md
+++ b/doc/funding/process.md
@@ -1,10 +1,10 @@
 # Process for funding
 
 Our process for funding is still a working draft.
-This is the process the board currently follows, and it will improve the details of this process as we begin taking our first steps.
+This is the process the Board currently follows, and it will improve the details of this process as we begin taking our first steps.
 
 - The [Board Chair](#board-chair) is accountable for ensuring the Board understands its budget.
 - [Subcommittees](#subcommittees) (or individual board members) make proposals for funding to the Board.
 - The Board takes a vote on whether to fund each proposal.
-- If proposals are accepted, the board will delegate the implementation of the proposal to a subcommittee or individual on the board.
+- If proposals are accepted, the Board will delegate the implementation of the proposal to a subcommittee or individual on the Board.
 - If subcommittees are responsible for implementing a proposal, then a **majority vote of the Governing Board members on the subcommittee** makes decision about how to spend the funds, as long as it is under the total amount in the proposal.   

--- a/doc/index.md
+++ b/doc/index.md
@@ -8,6 +8,8 @@ This Team Compass is very young and still a work in progress. It is likely missi
 
 ## Where information is located
 
+You can find most policy and practices of this group in **the site navigation to your left**. In addition the source files for this website are listed below.
+
 ### Our GitHub repository
 
 [Our GitHub repository](https://github.com/jupyter-governance/jupyter-foundation-governing-board) has all the source files for this team compass.

--- a/doc/myst.yml
+++ b/doc/myst.yml
@@ -15,13 +15,18 @@ project:
       jec: https://executive-council-team-compass.readthedocs.io/en/latest/
   toc:
     - file: index.md
-    - file: admin.md
+    - file: about.md
+    - file: strategy.md
+    - file: funding/priorities.md
+    - file: funding/process.md
     - file: finance.md
+    - file: communication.md
+    - file: admin.md
+    - file: contribute.md
     - title: Meeting Notes
       file: meetings/index.md
       children:
       - file: meetings/2025.md
-    - file: contribute.md
 site:
   template: book-theme
   options:

--- a/doc/strategy.md
+++ b/doc/strategy.md
@@ -1,0 +1,22 @@
+# Goals and strategy
+
+Our goal is to follow these strategic goals and priorities **through March of 2026**, with the plan of re-visiting this structure once we’ve gotten more experience and grown as a team.
+
+## Our 12 month goals
+
+The Foundation began operations this year, and so we define the following 12-month goals:
+
+1. Define the minimal structures needed to efficiently operate  
+2. Make quick progress in using Foundation funds to support Jupyter’s community  
+3. Learn as quickly as we can.  
+4. Prepare ourselves for more complex operations and decision making in the future.
+
+## Our strategy for achieving these goals
+
+Our current strategy is a **short-term strategy**. It is focused on helping us take our first steps, to have initial impact with our funds, and to learn. Here are major strategic priorities:
+
+1. **Focus on learning and taking quick, safe-to-try actions, rather than getting it perfect.** We’re a young team with a lot to learn, and our first job is to learn quickly how we can be most-effective in accomplishing our goals. It’s OK to make mistakes, as long as we learn, and as long as we are doing our best to live up to our goals.  
+2. **Prioritize using funds to deliver value to the Jupyter community.** Prioritize disbursing funds in a way that brings more resources, skills, etc into the Jupyter community. If the Jupyter Foundation needs staff for its own operations, aim to prioritize these for year two so that we can focus on learning for now.  
+3. **Identify opportunities that have a leveraged impact.** Use funding in ways that create force-multiplier effects. For example, by providing capacity that cuts across the sub-projects, by funding efforts that grow the overall capacity within Jupyter, etc. Don’t fund people just to continue an anti-pattern, but instead fund capacity to help Jupyter teams get *out* of anti-patterns.
+4. **Start by building a strong foundation of team and technology practices.** Rather than starting with new features and functionality, begin by ensuring that Jupyter’s subprojects have the resources and guidance they need to follow transparent and effective software development practices, leading to high-quality software and teams.  
+5. **Focus on listening and communication with both the Jupyter community and the member organizations, and provide a rationale for our decisions.** The Board should ensure that we actively communicate with the Jupyter community, and with the Foundation members. This will give us more community trust that makes it safer to spend funds in a creative and quick way.

--- a/doc/strategy.md
+++ b/doc/strategy.md
@@ -1,22 +1,22 @@
 # Goals and strategy
 
-Our goal is to follow these strategic goals and priorities **through March of 2026**, with the plan of re-visiting this structure once we’ve gotten more experience and grown as a team.
+Our goal is to follow these strategic goals and priorities **through March of 2026**, with the plan of revisiting this structure once we’ve had more experience and grown as a team.
 
-## Our 12 month goals
+## Our 12-month goals
 
-The Foundation began operations this year, and so we define the following 12-month goals:
+The Foundation ramped up its operation in early 2025. We define the following 12-month goals through early 2026:
 
-1. Define the minimal structures needed to efficiently operate  
-2. Make quick progress in using Foundation funds to support Jupyter’s community  
+1. Define the minimal structures needed to efficiently operate.
+2. Make quick progress in using Foundation funds to support Project Jupyter and its mission.  
 3. Learn as quickly as we can.  
-4. Prepare ourselves for more complex operations and decision making in the future.
+4. Prepare ourselves for more complex operations and decision-making in the future.
 
 ## Our strategy for achieving these goals
 
 Our current strategy is a **short-term strategy**. It is focused on helping us take our first steps, to have initial impact with our funds, and to learn. Here are major strategic priorities:
 
 1. **Focus on learning and taking quick, safe-to-try actions, rather than getting it perfect.** We’re a young team with a lot to learn, and our first job is to learn quickly how we can be most-effective in accomplishing our goals. It’s OK to make mistakes, as long as we learn, and as long as we are doing our best to live up to our goals.  
-2. **Prioritize using funds to deliver value to the Jupyter community.** Prioritize disbursing funds in a way that brings more resources, skills, etc into the Jupyter community. If the Jupyter Foundation needs staff for its own operations, aim to prioritize these for year two so that we can focus on learning for now.  
+2. **Prioritize using funds to deliver value to Project Jupyter.** Prioritize disbursing funds in a way that brings more resources, skills, etc into the Jupyter community. If the Jupyter Foundation needs staff for its own operations, aim to prioritize these for year two so that we can focus on learning for now.  
 3. **Identify opportunities that have a leveraged impact.** Use funding in ways that create force-multiplier effects. For example, by providing capacity that cuts across the sub-projects, by funding efforts that grow the overall capacity within Jupyter, etc. Don’t fund people just to continue an anti-pattern, but instead fund capacity to help Jupyter teams get *out* of anti-patterns.
 4. **Start by building a strong foundation of team and technology practices.** Rather than starting with new features and functionality, begin by ensuring that Jupyter’s subprojects have the resources and guidance they need to follow transparent and effective software development practices, leading to high-quality software and teams.  
-5. **Focus on listening and communication with both the Jupyter community and the member organizations, and provide a rationale for our decisions.** The Board should ensure that we actively communicate with the Jupyter community, and with the Foundation members. This will give us more community trust that makes it safer to spend funds in a creative and quick way.
+5. **Focus on listening and communication with both the Jupyter community and the member organizations, and provide a rationale for our decisions.** The Board should ensure that we actively communicate with the Jupyter community and with the Foundation members. This will give us more community trust, which will make it safer to spend funds in a creative and quick way.


### PR DESCRIPTION
This adds several high-level strategic and structural sections to our team compass, based on a recent Board vote to adopt these practices. It implements that decision by encoding it in our compass, and thus I believe it just needs approval from one other board member in order to merge.

Could somebody take a look at this and let me know if it reflects our recent decisions? If so, we can merge and then communicate our progress.

- closes https://github.com/jupyter-governance/jf-governing-board-private/issues/16