### PR TITLE
Remove old template for meeting notes

### DIFF
--- a/doc/meetings/2025.md
+++ b/doc/meetings/2025.md
@@ -1,10 +1,5 @@
 # 2025 Meeting Notes
 
-% COPY AND PASTE THE TEMPLATE BELOW
-% ## MMM, DDth, YYYY
-% ### Attendees
-% ### Notes 
-
 ## 2025 June 13
 A meeting of the Governing Board of the Jupyter Foundation was held on 13th June 2025 at 8:00 Pacific Daylight Time via teleconference.
 


### PR DESCRIPTION
Rus pointed out that we still had this old template for notes at the top of the file, which we can remove now with the new process for posting notes.