### PR TITLE
Add guidelines for updated funding process

### DIFF
--- a/doc/about.md
+++ b/doc/about.md
@@ -1,4 +1,4 @@
-# About us
+# About the foundation
 
 ## The Jupyter Foundation Charter
 

--- a/doc/about.md
+++ b/doc/about.md
@@ -1,4 +1,4 @@
-# About the Jupyter Foundation
+# About us
 
 ## The Jupyter Foundation Charter
 
@@ -18,66 +18,6 @@ However, Jupyter’s community is often opaque and has many different stakeholde
 
 ## Who we are
 
-* [Jupyter Foundation Governing Board](https://jupyter.org/governance/people.html#jupyter-foundation-governing-board)
-* [Jupyter Foundation Members](https://jupyterfoundation.org/members/)
-
-## How we are structured
-
-The Jupyter Foundation structure is defined [here in the Jupyter governance documentation](https://jupyter.org/governance/jupyter_foundation.html#membership).
-
-In addition, there are a few specific roles and groups defined within the Jupyter Foundation and its Governing Board, described below.
-
-(board-chair)=
-### Board Chair
-
-The Board Chair leads the Jupyter Foundation Governing Board ("Board") in conducting discussion and decisions that accomplish the Board's goals. The Board is intentionally keeping this role scoped tightly, to recognize that we are bootstrapping the role and to recognize that detailed responsibilities will be *defined* by the Board Chair in partnership with the Board. Below are the responsibilities for this role:
-
-- Plan and lead Board meetings  
-- Set the agenda   
-  - Define objectives - make sure the agenda matches the objectives.  
-- Coordinate with the [Linux Foundation Program Manager](#program-manager) to assist the board  
-  - Review meeting agendas, budget, minutes, etc.  
-- Facilitate the creation and delegation of authority / responsibility to Jupyter Foundation subcommittees
-
-#### Who is the current Board Chair?
-
-[Rus Pandey](https://www.linkedin.com/in/rusp/) is the Foundation Board's current Board Chair.
-
-#### How is the board chair elected?
-
-The Board elects a chair with a majority vote of its members.
-
-### Board Treasurer
-
-The Board Treasurer is the primary point of contact with LF around the budget.
-Here's a summary of their major responsibilities:
-
-- Meet regularly with LF administrators that represent budget (e.g. Monthly)
-- Receive monthly reports from LF
-- Communicate those reports to the board
-
-(subcommittees)=
-### Subcommittees
-
-A subcommittee is an ongoing working group of Board members that focuses on a thematic area over time. They were initially formed around [the Foundation's goals and strategy](./strategy.md).
-
-#### What is the purpose of subcommittees?
-
-The primary goals of subcommittees are to:
-
-- Make proposals to the Foundation Board that accomplish the goals in their thematic area.
-- Oversee the implementation of funds according to proposals that have been accepted, where applicable.
-
-#### How do we determine membership of subcommittees?
-
-By default, subcommittees are only open to Foundation Board members. However, subcommittees may elect to open their membership to all Foundation members.
-
-If a subcommittee has members that are not also on the Board, then any decisions around funding must be made with a majority vote of the Board members on the subcommittee.
-
-#### List of subcommittees
-
-This is still a work in progress. The Board has initially defined the following subcommittees:
-
-- **Technical Support Committee** - dedicated to improving the quality, reliability, and safety of Project Jupyter's software.
-- **Community Support Committee** - dedicated to improving the health of Project Jupyter's contributor community.
-- **Foundation Membership Development Committee** - dedicated to ensuring that the Jupyter Foundation membership grows and benefits from the Foundation.
+* Board members: [Jupyter Foundation Governing Board](https://jupyter.org/governance/people.html#jupyter-foundation-governing-board)
+* Member organizations: [Jupyter Foundation Members](https://jupyterfoundation.org/members/)
+* Team structure: @structure

--- a/doc/admin.md
+++ b/doc/admin.md
@@ -6,11 +6,11 @@ If you need reimbursement from the Linux Foundation, here are instructions:
 
 1. Collect all receipts for your expenses.
 1. Download and fill out the [LF Expense Report Template](https://docs.google.com/spreadsheets/d/10spMFQ23mZqwXHXBeY3kNcab5nf4SW3k/edit?gid=1152712870#gid=1152712870).
-1. Submit the template to our [](#program-manager) along with your receipts.
+1. Submit the template to our [](#role:program-manager) along with your receipts.
 1. LF Accounting will send you a request via [bill.com](https://bill.com) for your account information for reimbursement.
 
-(program-manager)=
-## Jupyter's Program Manager
+(role:program-manager)=
+## Jupyter's LF Program Manager
 
 The Program Manager is our primary point-of-contact with the Linux Foundation, and is the best person to ask for any questions involving LF processes.
 The best way to send messages is via e-mail, please ask another Foundation member if you need it.
@@ -36,7 +36,7 @@ We have a few different avenues for support from the Linux Foundation.
 ### Use the LF support e-mail
 
 The easiest route is to e-mail `support@jupyterfoundation.org` with your question, and they'll get back to you.
-You can also reach out to [our Program Manager](#program-manager), who monitors this e-mail.
+You can also reach out to [our Program Manager](#role:program-manager), who monitors this e-mail.
 
 ### Open a Jira ticket
 

--- a/doc/funding/budget.md
+++ b/doc/funding/budget.md
@@ -1,0 +1,44 @@
+# Budget allocations
+
+This page describes the current % allocations of our budget.
+See @priorities for more information about the goals and outcomes this budget is meant to support.
+
+Budget allocations are distributed in 2 phases:
+
+- Half 1 (H1, January - June)
+- Half 2 (H2, July - December)
+
+Any unspent funds remaining at the end of the half will be returned to the general pool for mid-year reallocation.
+
+Amendments to budget allocations may be approved with a vote from the board, with input from the [Treasurer](#role:treasurer) and [Board Chair](#role:chair), and financial validation from the [LF Program Manager](#role:program-manager) and Accountant.
+
+```{list-table} Budget Allocation by Category
+:header-rows: 1
+:name: budget-allocation
+
+* - Category
+  - \% of budget
+  - Purpose
+  - Goal
+  - Relevant Voting Body / Stakeholder
+* - Community
+  - 25%
+  - Support initiatives that build and sustain the contributor community, including DEI, mentorship, documentation, onboarding, and contributor recognition.
+  - @goal:capacity
+  - [Community Subcommittee](#list-of-subcommittees)
+* - Technical
+  - 25%
+  - Fund core project maintenance, modernization, and technical innovation, including architectural work, accessibility, security improvements and AI-related initiatives.
+  - @goal:software
+  - [Technical Subcommittee](#list-of-subcommittees)
+* - Events
+  - 25%
+  - Support global community engagement through events like JupyterCon, regional meetups, and workshops.
+  - Foster global collaboration, knowledge-sharing, and visibility of Jupyter tools.
+  - Linux Foundation (non-voting)
+* - Operations and admin
+  - 10%
+  - Cover operational expenses such as legal fees, trademark protection, security coordination, board meetings, and infrastructure.
+  - Ensure smooth governance and legal continuity of the Foundation's operations.
+  - Linux Foundation (non-voting)
+```

--- a/doc/funding/finance.md
+++ b/doc/funding/finance.md
@@ -1,4 +1,4 @@
-# Accounting and finances
+# Accounting and finance information
 
 ## Where can I find the budget?
 

--- a/doc/funding/priorities.md
+++ b/doc/funding/priorities.md
@@ -1,8 +1,9 @@
 
 # Funding priorities
 
-_We agreed upon the following areas to prioritize for funding. These were identified as critical shared needs by both the Jupyter Community as well as the Member organizations._
+The following priorities are the primary outcomes that the Foundation is prioritizing for funding.
 
+(goal:capacity)=
 ## Grow the contributor capacity of Jupyter
 
 A consistent challenge within Jupyter’s community is the lack of resources and time to maintain and develop its technology and community. At the same time, Foundation Member organizations have many people who are interested in contributing, but face barriers to doing so.
@@ -17,7 +18,7 @@ _These are likely not exhaustive, but are included to help us understand the kin
 2. **Improve the efficiency of our contributors.** It takes less effort to maintain and develop technology in the Jupyter ecosystem. This includes reducing toil, automating common actions, defining processes and responsibility that helps us execute more reliably and effectively, etc.  
 3. **Facilitate learning across the Jupyter subprojects.** Currently many subprojects act as independent and self-contained teams. They do not have a reliable way for learning from others in the Jupyter ecosystem, sharing resources, and sharing skills. Creating mechanisms for connecting these separate parts of the Jupyter ecosystem will result in more coherent and efficient actions across its community.
 
-### Examples of how to grow contributor capacity
+### Example activities
 
 - Hold events that grow Jupyter’s visibility and presence.  
 - Hold events that give newcomers an opportunity to collaborate with maintainers in real-time to gain comfort with participating in the project.  
@@ -28,6 +29,7 @@ _These are likely not exhaustive, but are included to help us understand the kin
 - Fund maintainer time to steward contributions from external contributors and provide them feedback with the goal of increasing their comfort with contributing.  
 - Fund development work on maintainer infrastructure that reduces toil and grows efficiency (e.g., improving the Jupyter Releaser technology and documentation)
 
+(goal:software)=
 ## Improve the reliability, security, and consistency of Jupyter’s software
 
 Many of Jupyter’s repositories lack the capacity needed to be considered reliable, safe, and consistent. This is due to a combination of bandwidth constraints, tooling, training, and coordination. As a result, Jupyter’s subprojects often accrue technical debt that burns out their maintainers, and that increases the variability of their outputs. Member organizations have a desire for Jupyter’s technology to be *reliable, safe, and consistent*. This allows them to confidently build their own technical dependencies on Jupyter technology and use them in production contexts.
@@ -43,7 +45,7 @@ _These are likely not exhaustive, but are included to help us understand the kin
 3. **Increase the frequency and transparency of minor releases.** “Release early, release often”, with an emphasis on minor releases providing bug fixes, security patches, non-disruptive performance improvements, and similarly non-disruptive new features. Ensure that releases always make it clear what has changed and what it means for a user. Minor releases with these characteristics are easier for Jupyter users and operators to deploy. This pattern also keeps the contributors familiar with the release process.  
 4. **Increase the speed of security fixes.** Security vulnerabilities are a strong concern for organizations that deploy Jupyter technology as part of shared services. Improvements to Jupyter’s overall software quality should result in faster, more efficient processes for identifying, resolving, and releasing security errors.
 
-### Examples of how to improve Jupyter software reliability, security, and consistency
+### Example activities
 
 - Hold events that allow subprojects to meet and co-work to solve their most pressing problems.  
 - Fund contributor time to focus on security, testing coverage, etc.  
@@ -65,7 +67,7 @@ _These are likely not exhaustive, but are included to help us understand the kin
 - **Jupyter Foundation members find value in their membership**. The primary goal of this group is to ensure that the members of the Jupyter Foundation are engaged, see their interests represented, and generally see value in their membership with the Jupyter Foundation.
 - **The Jupyter Foundation has the resources it needs to accomplish its goals**. In order to ensure that the Foundation can meet its goals, the Foundation needs financial resources from its paying members. This committee also aims to grow the Foundation to a level that allows it to accomplish its goals.
 
-### Examples of how to develop the Foundation
+### Example activities
 
 - Identify the necessary roles to sustain the Foundation operations (e.g., Treasurer, Executive Director)
 - Create feedback loops between the Jupyter community, the Jupyter Executive Council, Member Organizations, and the Foundation (both synchronous and asynchronous)  

--- a/doc/funding/process.md
+++ b/doc/funding/process.md
@@ -22,8 +22,8 @@ Here's the structure of a proposal:
    :::
 2. **Proposer creates a thread on Discourse**: This is for feedback and discussion around the proposal, linked from the issue.
    :::{warning} TODO
-   - Link to the sub-category in Discourse
-   - Link to open a Discourse thread directly?
+   - Link to the sub-category in [the Community Forum](https://discourse.jupyter.org)
+   - Link to open a forum thread directly?
    :::
 3. **Proposer starts drafting**: When the idea is concrete-enough, the proposer drafts language for the proposal. Use [the Proposal Template](https://docs.google.com/document/d/101cNUZbGCWUMn8LbDiSRjL5Q78e_31gN4-FqCiSp47o/edit?tab=t.5inaorn0ect5#heading=h.5i77we14fyb) and link it to the GitHub issue.
 4. **Submit Proposal**: Submit the proposal for review by a subcommittee by `???` (marking a github status? changing the proposal metadata in a google doc?)
@@ -43,10 +43,8 @@ Here's the structure of a proposal:
    - **Reject**: Funds are not approved and the process ends for this proposal.
    - **Request revisions**: Funds are not approved, with an invitation to re-submit via the subcommittee.
 7. **Sign-Off by LF Team**: The [Treasurer](#role:treasurer) coordinates with the [LF Program Manager](#role:program-manager) and Accountant for financial validation and compliance.
-   :::{warning} TODO
-   - How is this formally encoded? Is there a status or documentation somewhere to note when this has been done?
-   :::
-8. **Execution and Reporting**: Once approved, funds are disbursed by LF (the specific mechanism and timing will depend on the proposal). Proposal owners execute the work and provide a brief report on fund usage (quarterly or upon completion).
+8. **Execution**: Once approved, funds are disbursed by LF (the specific mechanism and timing will depend on the proposal). Proposal owners are responsible for ensuring the work is executed.
+9. **Reporting**. Proposal owners should provide regular updates to the Foundation board, ideally in the form of public blog posts. At least one public blog post should be communicated describing the outcomes of the funding effort.
 
 ### Example schedule
 
@@ -65,10 +63,8 @@ While the board is preparing to vote on one batch of proposals (e.g., for the Se
 
 - Focus on the outcomes and the value to the community, not implementation details.
 - Focus on our [funding priorities](priorities.md) and [board strategy](../strategy.md).
-- The smaller the budget you're proposing, the higher chance it will be accepted.[^budget-total]
+- The smaller the budget you're proposing, the higher chance it will be accepted.
 - The more support you can show from the community, the higher chance it will be accepted.
-
-[^budget-total]: As a rule of thumb for deciding what "a large" funding ask would be, assume the Foundation has on the order of `$1M` in total funds to work with.
 
 ## Who can propose funding?
 

--- a/doc/funding/process.md
+++ b/doc/funding/process.md
@@ -4,7 +4,15 @@ This describes the process that the board and the Jupyter community follow in or
 
 Submissions are accepted on a rolling basis throughout the year, with funds being released according to our [budget allocations](./budget.md). 
 
-## Step by step overview
+## Proposal structure
+
+Here's the structure of a proposal:
+
+- **A GitHub issue** tracks each proposal's status and metadata. Use [this issue template](TODO: Link to template).
+- **A Google Doc** contains the proposal text. Use [this proposal template](TODO: LINK TO TEMPLATE).
+- **A GitHub Project Board** tracks the status of all proposals. See [this proposals board](TODO: ADD LINK).
+
+## Overview of the process
 
 1. **Proposer creates an issue on GitHub**: This issue gets added to a Proposals Project Board in a “Drafting” state. This is for scoping the big idea and getting others on board.
 
@@ -53,25 +61,15 @@ To illustrate how this cadence works in practice. Let’s consider example sched
 While the board is preparing to vote on one batch of proposals (e.g., for the September 19th meeting), subcommittees should already be reviewing and nominating the **next batch of proposals** for the following month’s meeting. This rolling cadence ensures there is no downtime between proposal cycles and keeps momentum across quarters.
 :::
 
-## How to create a proposal
+## Tips for writing a proposal
 
-We will track proposals in the queue and their status on GitHub (i.e., we will use GitHub for project management). Actual proposals will be drafted in Google Docs and will use a proposal template for ease of review. On GitHub, each ticket should have:
+- Focus on the outcomes and the value to the community, not implementation details.
+- Focus on our [funding priorities](priorities.md) and [board strategy](../strategy.md).
+- The smaller the budget you're proposing, the higher chance it will be accepted.[^budget-total]
+- The more support you can show from the community, the higher chance it will be accepted.
 
-:::{note} The annual proposal cycle ends in September
-This ensures that all approved proposals have sufficient time to execute and report before the end of the fiscal year, giving proposers a full quarter to utilize the funds.
-:::
-
-- Proposal Name
-- Link to Proposal
-- Link to discussion thread on Discourse
-- Submitter/Contact
-- Date submitted
-- Category (see above)
-- Status
+[^budget-total]: As a rule of thumb for deciding what "a large" funding ask would be, assume the Foundation has on the order of `$1M` in total funds to work with.
 
 ## Who can propose funding?
 
 Anybody can propose funding following the process above, and we encourage community members to do so as collaborative efforts.
-
----
-

--- a/doc/funding/process.md
+++ b/doc/funding/process.md
@@ -1,15 +1,77 @@
-# Process for funding
+# Process for funding proposals
 
-This is the process the Board currently follows, and it will improve the details of this process as we begin taking our first steps.
+This describes the process that the board and the Jupyter community follow in order to unlock funds from the Foundation.
 
-- The [Board Chair](#board-chair) is accountable for ensuring the Board understands its budget.
-- [Subcommittees](#subcommittees) (or individual board members) make proposals for funding to the Board.
-- The Board takes a vote on whether to fund each proposal.
-- If proposals are accepted, the Board will delegate the implementation of the proposal to a subcommittee or individual on the Board.
-- If subcommittees are responsible for implementing a proposal, then a **majority vote of the Governing Board members on the subcommittee** makes decision about how to spend the funds, as long as it is under the total amount in the proposal.   
+Submissions are accepted on a rolling basis throughout the year, with funds being released according to our [budget allocations](./budget.md). 
 
-## How to submit a proposal for funding
+## Step by step overview
 
-- Go to [this proposal template](https://docs.google.com/document/d/101cNUZbGCWUMn8LbDiSRjL5Q78e_31gN4-FqCiSp47o/edit?usp=sharing)
-- Duplicate it into a new document (it should be placed in the `Funding Proposals` folder in the Board's Google Drive).
-- Follow the instructions in the template.
+1. **Proposer creates an issue on GitHub**: This issue gets added to a Proposals Project Board in a “Drafting” state. This is for scoping the big idea and getting others on board.
+
+   :::{warning} TODO
+   - Link to proposals project board
+   - Link to draft issue link.
+   :::
+2. **Proposer creates a thread on Discourse**: This is for feedback and discussion around the proposal, linked from the issue.
+   :::{warning} TODO
+   - Link to the sub-category in Discourse
+   - Link to open a Discourse thread directly?
+   :::
+3. **Proposer starts drafting**: When the idea is concrete-enough, the proposer drafts language for the proposal. Use [the Proposal Template](https://docs.google.com/document/d/101cNUZbGCWUMn8LbDiSRjL5Q78e_31gN4-FqCiSp47o/edit?tab=t.5inaorn0ect5#heading=h.5i77we14fyb) and link it to the GitHub issue.
+4. **Submit Proposal**: Submit the proposal for review by a subcommittee by `???` (marking a github status? changing the proposal metadata in a google doc?)
+
+   :::{warning} TODO
+   - Link to proposals project board
+   - Link to draft issue link.
+   :::
+5. **Subcommittee Review**: Subcommittees review proposals and recommend next actions.[^expectations] The GitHub issue is moved to “In Review” in the Project Board. Here are a few potential outcomes from the review process:
+   - Recommend the proposal for board vote
+   - Request revisions from the proposer
+   - Reject low-quality or misaligned submissions without a general board vote.
+
+  [^expectations]: Subcommittees should nominate proposals at least two weeks ahead of the second general board meeting of the month. If the subcommittee does not provide feedback within the review window, the proposal may still proceed to board vote at the discretion of the Treasurer and Board Chair to avoid unnecessary delays.
+6. **Board Review and Vote**: All subcommittee-nominated proposals are reviewed and voted on during the second board meeting of each month. Here are potential outcomes from the board:
+   - **Accept**: Funds are approved by the board and move to approval by LF.
+   - **Reject**: Funds are not approved and the process ends for this proposal.
+   - **Request revisions**: Funds are not approved, with an invitation to re-submit via the subcommittee.
+7. **Sign-Off by LF Team**: The [Treasurer](#role:treasurer) coordinates with the [LF Program Manager](#role:program-manager) and Accountant for financial validation and compliance.
+   :::{warning} TODO
+   - How is this formally encoded? Is there a status or documentation somewhere to note when this has been done?
+   :::
+8. **Execution and Reporting**: Once approved, funds are disbursed by LF (the specific mechanism and timing will depend on the proposal). Proposal owners execute the work and provide a brief report on fund usage (quarterly or upon completion).
+
+### Example schedule
+
+To illustrate how this cadence works in practice. Let’s consider example schedules for August and September.  
+
+| Subcommittee nomination deadline (2 weeks from board vote) | Board vote (2nd board meeting of the month) | Disbursement (Target) |
+| :---- | :---- | :---- |
+| Friday August 8th | Friday August 22nd  | September 1st  |
+| Friday September 5th | Friday September 19th | October 1st  |
+
+:::{note}
+While the board is preparing to vote on one batch of proposals (e.g., for the September 19th meeting), subcommittees should already be reviewing and nominating the **next batch of proposals** for the following month’s meeting. This rolling cadence ensures there is no downtime between proposal cycles and keeps momentum across quarters.
+:::
+
+## How to create a proposal
+
+We will track proposals in the queue and their status on GitHub (i.e., we will use GitHub for project management). Actual proposals will be drafted in Google Docs and will use a proposal template for ease of review. On GitHub, each ticket should have:
+
+:::{note} The annual proposal cycle ends in September
+This ensures that all approved proposals have sufficient time to execute and report before the end of the fiscal year, giving proposers a full quarter to utilize the funds.
+:::
+
+- Proposal Name
+- Link to Proposal
+- Link to discussion thread on Discourse
+- Submitter/Contact
+- Date submitted
+- Category (see above)
+- Status
+
+## Who can propose funding?
+
+Anybody can propose funding following the process above, and we encourage community members to do so as collaborative efforts.
+
+---
+

--- a/doc/meetings/index.md
+++ b/doc/meetings/index.md
@@ -11,7 +11,7 @@ After each meeting we also approve _public_ meeting minutes and post them in thi
 
 After each meeting, here's how we approve meeting minutes.
 
-- Our [Program Manager](#program-manager) will finalize the meeting minutes.
+- Our [Program Manager](#role:program-manager) will finalize the meeting minutes.
 - Each board member will get an e-mail noting that the minutes are ready for review.
 - Each board member reviews the minutes, and votes to approve them [via the LF OpenDev portal](#lf-dashboard).
 

--- a/doc/meetings/index.md
+++ b/doc/meetings/index.md
@@ -16,6 +16,10 @@ We follow a ["lazy consensus" model](https://community.apache.org/committers/dec
 - **Approval without changes**: If no changes are suggested during the initial review, the minutes will be automatically approved.
 - **Changes are proposed**: The Review period will extend by 1 week.
 
+## Public meeting minutes
+
+After each board meeting, the [](#role:program-manager) prepares a version of the minutes meant for release to the public.
+They propose this as a Pull Request to the Foundation Board team compass. Any board member is encouraged to merge it.
 ## Where to find public meeting minutes?
 
 Below are the minutes from each year of the Foundation Governing Board:

--- a/doc/meetings/index.md
+++ b/doc/meetings/index.md
@@ -20,6 +20,7 @@ We follow a ["lazy consensus" model](https://community.apache.org/committers/dec
 
 After each board meeting, the [](#role:program-manager) prepares a version of the minutes meant for release to the public.
 They propose this as a Pull Request to the Foundation Board team compass. Any board member is encouraged to merge it.
+
 ## Where to find public meeting minutes?
 
 Below are the minutes from each year of the Foundation Governing Board:

--- a/doc/myst.yml
+++ b/doc/myst.yml
@@ -10,16 +10,20 @@ project:
   abbreviations:
     LF: The Linux Foundation
     JEC: Jupyter Executive Council
-  project:
-    references:
-      jec: https://executive-council-team-compass.readthedocs.io/en/latest/
+  references:
+    jec: https://ec.jupyter.org
   toc:
     - file: index.md
     - file: about.md
+      children:
+        - file: structure.md
     - file: strategy.md
-    - file: funding/priorities.md
-    - file: funding/process.md
-    - file: finance.md
+    - title: Funding and proposals
+      children:
+      - file: funding/priorities.md
+      - file: funding/budget.md
+      - file: funding/process.md
+      - file: funding/finance.md
     - file: communication.md
     - file: admin.md
     - file: contribute.md

--- a/doc/structure.md
+++ b/doc/structure.md
@@ -1,0 +1,67 @@
+# Team structure
+
+The Jupyter Foundation structure is defined [here in the Jupyter governance documentation](https://jupyter.org/governance/jupyter_foundation.html#membership).
+
+In addition, there are a few specific roles and groups defined within the Jupyter Foundation and its Governing Board, described below.
+
+(board-chair)=
+## Board Chair
+
+The Board Chair leads the Jupyter Foundation Governing Board ("Board") in conducting discussion and decisions that accomplish the Board's goals. Below are the responsibilities for this role:
+
+- Plan and lead Board meetings  
+- Set the agenda   
+  - Define objectives - make sure the agenda matches the objectives.  
+- Coordinate with the [Linux Foundation Program Manager](#role:program-manager) to assist the board  
+  - Review meeting agendas, budget, minutes, etc.  
+- Facilitate the creation and delegation of authority / responsibility to Jupyter Foundation subcommittees
+
+(role:chair)=
+### Current Board Chair
+
+[Rus Pandey](https://www.linkedin.com/in/rusp/) is the Foundation Board's current Board Chair.
+
+### How is the board chair elected?
+
+The Board elects a chair with a majority vote of its members.
+
+## Board Treasurer
+
+The Board Treasurer is the primary point of contact with LF around the budget.
+Here's a summary of their major responsibilities:
+
+- Meet regularly with LF administrators that represent budget (e.g. Monthly)
+- Receive monthly reports from LF
+- Communicate those reports to the board
+
+(role:treasurer)=
+### Current Board Treasurer
+
+[Savannah (Ostrowski) Bailey](https://www.linkedin.com/in/savannahostrowski/) is the current Board Treasurer.
+
+(subcommittees)=
+## Subcommittees
+
+A subcommittee is an ongoing working group of Board members that focuses on a thematic area over time. They were initially formed around [the Foundation's goals and strategy](./strategy.md).
+
+### What is the purpose of subcommittees?
+
+The primary goals of subcommittees are to:
+
+- Make proposals to the Foundation Board that accomplish the goals in their thematic area.
+- Oversee the implementation of funds according to proposals that have been accepted, where applicable.
+
+### How do we determine membership of subcommittees?
+
+By default, subcommittees are only open to Foundation Board members. However, subcommittees may elect to open their membership to all Foundation members.
+
+If a subcommittee has members that are not also on the Board, then any decisions around funding must be made with a majority vote of the Board members on the subcommittee.
+
+(list-of-subcommittees)=
+### List of subcommittees
+
+This is still a work in progress. The Board has initially defined the following subcommittees:
+
+- **Technical Support Committee** - dedicated to improving the quality, reliability, and safety of Project Jupyter's software.
+- **Community Support Committee** - dedicated to improving the health of Project Jupyter's contributor community.
+- **Foundation Membership Development Committee** - dedicated to ensuring that the Jupyter Foundation membership grows and benefits from the Foundation.


### PR DESCRIPTION
This adds guidelines for our updated funding process approved last week. It took the language @savannahostrowski put together and tried to simplify it a little bit to make this easier to use for reference documentation.

It's not totally complete, but I think it's safe to merge if we'd like to iterate from here. @Naomi-Wash will need to update some of these docs (particularly `funding/process.md`) when we have more specific links to share for where others can go to follow the process.

This also cleans up a bit of language here and there, improves our cross-referencing, etc. But nothing major or semantic.