### PR TITLE
Add meeting notes for May 1, 2026

### DIFF
--- a/doc/meetings/2026.md
+++ b/doc/meetings/2026.md
@@ -90,7 +90,7 @@ Naomi Washington shared that the pricing for Jupyter at PyTorch Conference is st
 
 **Community Proposal**
 
-Michal Krassowski provided background on the proposal for a part-time security role for Jupyter, explaining that the rise of AI is leading to duplicated submissions and increasing the need for triage, answering emails, and other coordination. Krassowski noted that he already has a candidate in mind at his company.
+Michal Krassowski provided background on the proposal for a part-time security role for Jupyter, explaining that the rise of AI is leading to duplicated submissions and increasing the need for triage, answering emails, and other coordination. Krassowski noted that the proposal author has an independent candidate in mind.
 
 The Governing Board approved the community proposal, Part-time security role for Jupyter.
 

--- a/doc/meetings/2026.md
+++ b/doc/meetings/2026.md
@@ -1,0 +1,78 @@
+# 2026 Meeting Notes
+
+## 2026 May 1
+A meeting of the Governing Board of the Jupyter Foundation was held on 2026 May 1 at 8:00 AM Pacific Daylight Time via teleconference.
+
+### Attendees
+
+| Company | | Premier Member Voting Rep | | Alternate Premier Rep|
+| ------------- | ------------- | ------------- | ------------- |------------- |
+| AWS | x | Brian Granger | | Piyush Jain |
+| Google | x | Eric Johnson | | Shane Glass |
+| Apple | x | Rus Pandey (Chair) | x | Neha Singla (Treasurer) |
+
+
+### Introduction
+
+Rus Pandey called the meeting to order at 8:05 AM Pacific Daylight Time, and Naomi Washington recorded the minutes. 
+A quorum of Governing Board Members was established for the conduct of business, and the meeting, having been duly convened, was ready to proceed with business.
+
+### Minutes
+
+Naomi Washington shared that the minutes from the 2026 April 3 meeting were approved and adopted via lazy consensus.
+
+Washington shared that previous Governing Board minutes were not added to the public calendar due to an oversight, and she will now work backward to add them.
+
+**Member Updates**
+
+Washington informed the governing board that Posit has joined the foundation as a general member, 
+
+**Community Manager Update & Discussion**
+
+Washington informed the governing board that with 12 of 14 governing board approvals, it was passed the appointment of Jason Grout as Jupyter Foundation Community Manager for a 6-month contract-based role
+It was decided that Grout will have access to the Governing Board and subcommittees as an observer.
+
+**Technical Subcommittee**
+
+Naomi Washington presented the Technical Subcommittee update on the Jupyter User Experience Survey, noting that the Governing Board is first asked to complete the survey to ensure it reflects the desired Foundation outcomes before its distribution to the broader community for one month. 
+The Governing Board chair shared uncertainty about the technical subcommittee's future focus and requested guidance on how the governing board could help.
+A board member mentioned an AI community that may be of interest to the larger governing board.
+
+**Marketing Subcommittee**
+
+Jake Diamond-Reivich provided an update on recent marketing efforts, informing the Governing Board that marketing for Jupyter AI V3 begins next week. Content is being planned, including an announcement blog, a demo video, a support webpage, and various media appearances. Diamond-Reivich also shared details on upcoming events, noting that the Jupyter AI Dev Summit 2 will take place in May and again in September, and that the Marketing Committee has submitted proposals to four other conferences. He requested that the Governing Board promote the AI events on the foundation member social media channels and recommend attendees for the dev summits.
+
+Stephanie Stattel expressed interest in planning Jupyter Studio days this year in the San Francisco and London offices and inquired about the feasibility of pairing with the Marketing Committee later in the year for promotion. Stattel was encouraged to join the Marketing Committee or send an alternate to participate. Jake Diamond-Reivich noted that he will reach out to Stattel to partner and get more information, and he mentioned creating a checklist to make it easier for members to participate in Jupyter AI and other areas. 
+
+Rus Pandey suggested involving more engineers in Jupyter AI interviews and other activities to develop those people to represent the community in the work they have done.
+
+**Community Subcommittee**
+
+Celeste Horgan stated that discussing with Jason Grout in his part-time role is the first priority in future efforts on the subcommittee. She also noted that the AI Summit is happening at the end of May and that coordination is underway, with Snowflake serving as a host. The subcommittee plans to determine what is on Grout's immediate radar, as there may be an opportunity to broaden the community subcommittee's efforts with the larger community. 
+
+**Executive Council**
+
+Afshin Darian noted that the Executive Council (EC) is involved in many of the same discussions as in the Governing Board but expressed a desire for EC efforts to focus more on package releases, event highlights, and technical releases. Zach Sailer reported that the past quarter largely centered on the AI conversation, specifically navigating how to facilitate a positive conversation around AI and contributions to it. Sailer acknowledged the "slight tension and burden" on engineers due to the high volume of pull requests (PRs) and the demand to keep up with AI developments. He concluded that it is the EC's responsibility to create a top-level policy on AI, allowing sub-projects to build on that foundation. 
+
+Rus Pandey explained that the goal of requesting an EC update was to establish a dialogue between the EC and the Governing Board, solicit advice on how the board can help, and share interest in how the SSC (Strategic Steering Council) will evolve.
+
+**Events**
+
+Naomi Washington reported that registrations are open for the AI Developer Summits, with the San Francisco event having 10 registrations and the London event having 3. 
+
+Washington also announced that a half-day Jupyter Mini Summit will take place on Tuesday, October 6, 2026, at the Open Source Summit EU. A dedicated event page has been added to the Jupyter Foundation website, and the event will be listed on the main event website once a description is provided. Discussion followed regarding the primary focus for the Mini Summit, and it was decided that the content should be geared towards AI and a broader set of items.
+
+Stephanie Stattel inquired about sponsorships for the mini-summit, and Washington committed to following up with her after the meeting to connect with the event team
+
+Naomi Washington shared that the pricing for Jupyter at PyTorch Conference is still pending but will be available in the coming weeks. 
+
+**Community Proposal**
+
+Michal Krassowski provided background on the proposal for a part-time security role for Jupyter, explaining that the rise of AI is leading to duplicated submissions and increasing the need for triage, answering emails, and other coordination. Krassowski noted that he already has a candidate in mind at his company.
+
+The Governing Board approved the community proposal, Part-time security role for Jupyter.
+
+**Closing** 
+
+Rus Pandey thanked the attendees for their time and participation, called the meeting to a close, and the meeting of the Governing Board adjourned at 9:04 AM Pacific Standard Time.
+

--- a/doc/meetings/2026.md
+++ b/doc/meetings/2026.md
@@ -5,12 +5,34 @@ A meeting of the Governing Board of the Jupyter Foundation was held on 2026 May 
 
 ### Attendees
 
-| Company | | Premier Member Voting Rep | | Alternate Premier Rep|
-| ------------- | ------------- | ------------- | ------------- |------------- |
+| Company | | Governing Board Voting Member | | Governing Board Alternate |
+| - | - | - | - | - |
 | AWS | x | Brian Granger | | Piyush Jain |
 | Google | x | Eric Johnson | | Shane Glass |
 | Apple | x | Rus Pandey (Chair) | x | Neha Singla (Treasurer) |
+| Bloomberg | x | Stephanie Stattel |  | Alyssa Wright |
+| Meta |  | Yaniv Schahar |
+| Snowflake | x | Celeste Horgan |  | Danica Fine |
+| Uber | x | Vijay Mann |  | Praveen Muthusamy |
 
+| Company | | Executive Council Voting Member | | Governing Board Alternate |
+| - | - | - | - | - |
+| QuantStack | x | Afshin Darian "Darian" |
+| Plotly |  | Martha Cryan |
+| 2i2c | x | Chris Holdgraf |
+| Mito Labs | x | Jake Diamond-Reivich |
+| Argonne National Laboratory | x | Rick Wagner |
+| Apple | x | Zach Sailer |
+
+| Company | | General Member Representative | | Governing Board Alternate |
+| - | - | - | - | - |
+| OpenTeams | x | Michal Krassowski |
+
+| Linux Foundation Staff | |  |
+| - | - | - |
+| Program Manager | x | Naomi Washington |
+| Program Coordinator | x | Tom Slanda |
+| CRO | | Mike Woster |
 
 ### Introduction
 


### PR DESCRIPTION
Documented the meeting notes from the Governing Board of the Jupyter Foundation held on May 1, 2026, including attendees, discussions, and decisions made.