### PR TITLE
Add July 10, 2026 governing board meeting notes

### DIFF
--- a/doc/meetings/2026.md
+++ b/doc/meetings/2026.md
@@ -1,5 +1,93 @@
 # 2026 Meeting Notes
 
+## 2026 July 10
+A meeting of the Governing Board of the Jupyter Foundation was held on 2026 July 10 at 8:00 AM Pacific Daylight Time via teleconference.
+
+### Attendees
+
+| Company | | Governing Board Voting Member | | Governing Board Alternate |
+| - | - | - | - | - |
+| AWS |  | Piyush Jainr | x | Lahari Chowtoori |
+| Google |  | Eric Johnson | x | Shane Glass |
+| Apple | x | Rus Pandey (Chair) | x | Neha Singla (Treasurer) |
+| Bloomberg | x | Stephanie Stattel |  | Alyssa Wright |
+| Meta | x | Yaniv Schahar |
+| Snowflake |  | Celeste Horgan | x | Danica Fine |
+| Uber | x | Vijay Mann |  | Praveen Muthusamy |
+
+| Company | | Executive Council Voting Member | | Governing Board Alternate |
+| - | - | - | - | - |
+| QuantStack | x | Afshin Darian "Darian" |
+| Plotly |  | Martha Cryan |
+| 2i2c |  | Chris Holdgraf |
+| Mito Labs | x | Jake Diamond-Reivich |
+| Argonne National Laboratory | x | Rick Wagner |
+| Apple | x | Zach Sailer |
+
+| Company | | General Member Representative | | Governing Board Alternate |
+| - | - | - | - | - |
+| OpenTeams | x | Michal Krassowski |
+
+| Linux Foundation Staff | |  |
+| - | - | - |
+| Program Manager | x | Naomi Washington |
+| Program Coordinator | x | Tom Slanda |
+| CRO | x | Mike Woster |
+| SVP | x | Todd Moore |
+| Event Director | x | Deb Giles |
+
+|Observers | |  |
+| - | - | - |
+| Community Manager | x | Jason Grout |
+
+### Introduction
+
+Rus Pandey called the meeting to order at 8:04 AM Pacific Daylight Time and Tom Slanda recorded the minutes. A quorum of Governing Board Members was established for the conduct of business, and the meeting, having been duly convened, was ready to proceed with business.
+
+### Attendance, Antitrust, Voting
+
+Naomi Washington reminded the Governing Board of the Linux Foundation [Antitrust Policy Notice](https://www.linuxfoundation.org/legal/antitrust-policy) to which all meetings must adhere.
+
+Washington outlined the agenda of the meeting. 
+
+#### Agenda
+
+- Events
+   - Jupyter at PyTorchCon NA 2026
+- General Business
+   - Minutes
+   - Executive Director Update
+   - Next All Member Meeting
+- Community Funding Proposals
+- Subcommittee & Executive Council Report Outs
+- Open Discussion
+
+### Events
+Deb Giles provided information about the Jupyter Event being co-located at the PyTorch Conference NA on October 19, 2026.  Giles reported that attendees for the Jupyter event will not have to register for the PyTorch Conference.  Giles presented four potential packages for the Governing Board to choose from for the event.  Discussion ensued, and the Governing Board will decide in a week or two. 
+
+### General Business
+Washington reported that the June 5, 2026 meeting minutes were approved via lazy consensus.
+
+Pandey provided an update on the search for an Executive Director for the Jupyter Foundation.  Pandey requested that Governing Board members refer any qualified candidates to the job posting. 
+
+Jason Grout opened a discussion to gather feedback from the All-Member meeting held on June 25, 2026.  Grout reported that the next All-Member meeting is scheduled for September 9, 2026.  A board member recommended keeping agenda topics to “issues that are existential”.
+
+### Community Funding Proposals
+Washington reported that the 2026 Community Call for Funding Proposals is open until September 9, 2026.  Washington reviewed the timeline and said the Technical Subcommittee will discuss and finalize the proposal review process, then the Governing Board will have final approval.
+Subcommittee & Executive Council Report Outs
+Schahar provided an update from the Technical Subcommittee, including the Jupyter User Survey and the CFP.  Schahar added that the committee will review user survey responses in the coming weeks.  Pandey requested that the committee create a presentation on the results for the Governing Board meeting in August.
+
+Washington reported that she has reached out to the Community Subcommittee to plan the mini-summit, which will be co-located with the Open Source Summit Europe in October.  Washington added that conversations were happening in the Jupyter Community Building Working Group regarding the Jupyter website.
+
+Grout reported that the Executive Council has started discussions around consolidating some subprojects and councils.
+
+Jake Diamond-Reivich shared an update from the marketing committee, including content, media appearances, and future events.
+
+### Closing
+Rus Pandey thanked the attendees for their time and participation, called the meeting to a close, and the meeting of the Governing Board adjourned at 9:05 AM Pacific Standard Time.
+
+
+
 ## 2026 June 5
 A meeting of the Governing Board of the Jupyter Foundation was held on 2026 June 5 at 8:00 AM Pacific Daylight Time via teleconference.
 


### PR DESCRIPTION
Added detailed notes from the July 10, 2026 meeting of the Governing Board